### PR TITLE
add gradle-wrapper.properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,6 @@
 bin/
 gen/
 
-*.properties
-
 # Eclipse project files
 .classpath
 .project

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,5 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.2-all.zip


### PR DESCRIPTION
Jitpackでgradle2.2の指定がないとビルドできなかったので、gradle-wrapper.propertiesを追加した。